### PR TITLE
Fixed: Error in return statement function declaration annotator logic

### DIFF
--- a/src/cappuccino/ide/intellij/plugin/annotator/ObjJAnnotator.kt
+++ b/src/cappuccino/ide/intellij/plugin/annotator/ObjJAnnotator.kt
@@ -132,7 +132,7 @@ class ObjJAnnotator : Annotator {
         }
         val methodDeclaration = block.getParentOfType(ObjJMethodDeclaration::class.java)
         if (isFunction) {
-            annotateBlockReturnStatements(block.parent as ObjJFunctionDeclarationElement<*>, returnsWithExpression, returnsWithoutExpression, annotationHolder)
+            annotateBlockReturnStatements(block.getParentOfType(ObjJFunctionDeclarationElement::class.java)!!, returnsWithExpression, returnsWithoutExpression, annotationHolder)
         } else if (methodDeclaration != null) {
             annotateBlockReturnStatements(methodDeclaration, returnsWithExpression, returnsWithoutExpression, annotationHolder)
         }


### PR DESCRIPTION
Method was changed to use another way of resolving function declaration parent in plugin, but a later method call failed to resolve the element the same way