### PR TITLE
Removed: Method selector rename functionality

### DIFF
--- a/src/cappuccino/ide/intellij/plugin/contributor/ObjJRenameVetoCondition.kt
+++ b/src/cappuccino/ide/intellij/plugin/contributor/ObjJRenameVetoCondition.kt
@@ -1,5 +1,6 @@
 package cappuccino.ide.intellij.plugin.contributor
 
+import cappuccino.ide.intellij.plugin.psi.ObjJSelector
 import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJCompositeElement
 import cappuccino.ide.intellij.plugin.utils.ObjJFileUtil
 import com.intellij.openapi.util.Condition
@@ -7,6 +8,7 @@ import com.intellij.psi.PsiElement
 
 class ObjJRenameVetoCondition : Condition<PsiElement> {
     override fun value(element: PsiElement): Boolean {
-        return element is ObjJCompositeElement && ObjJFileUtil.isFrameworkElement(element)
+        return ObjJFileUtil.isFrameworkElement(element) ||
+                element is ObjJSelector
     }
 }

--- a/src/cappuccino/ide/intellij/plugin/references/ObjJSelectorReference.kt
+++ b/src/cappuccino/ide/intellij/plugin/references/ObjJSelectorReference.kt
@@ -202,6 +202,7 @@ class ObjJSelectorReference(element: ObjJSelector) : PsiPolyVariantReferenceBase
         return null
     }
 
+    // Rename is prevented by adding all ObjJSelector element to the Veto extension point
     override fun handleElementRename(selectorString: String): PsiElement {
         return ObjJPsiImplUtil.setName(myElement, selectorString)
     }


### PR DESCRIPTION
Method call rename was caused problems as it was not resolved to a single type of element. It has been removed to prevent problems that can occur due to brute force rename, renaming methods not intended.