### PR TITLE
Added: Project view error highlighting

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -110,7 +110,7 @@ from the Cappuccino github page([link](https://github.com/cappuccino/cappuccino 
     <annotator language="ObjectiveJ" implementationClass="cappuccino.ide.intellij.plugin.annotator.ObjJAnnotator" />
     <annotator language="ObjectiveJ" implementationClass="cappuccino.ide.intellij.plugin.annotator.ObjJSyntaxHighlighterAnnotator" />
     <!--codeInsight.parameterInfo language="ObjectiveJ" implementationClass="cappuccino.ide.intellij.plugin.contributor.handlers.ObjJParameterInfo" / -->
-
+    <problemFileHighlightFilter implementation="cappuccino.ide.intellij.plugin.lang.ObjJProblemFileHighlighterFilter" />
 
     <!-- Indices -->
     <applicationService serviceInterface="cappuccino.ide.intellij.plugin.indices.StubIndexService"

--- a/src/cappuccino/ide/intellij/plugin/lang/ObjJProblemFileHighlighterFilter.kt
+++ b/src/cappuccino/ide/intellij/plugin/lang/ObjJProblemFileHighlighterFilter.kt
@@ -1,0 +1,11 @@
+package cappuccino.ide.intellij.plugin.lang
+
+import com.intellij.openapi.util.Condition
+import com.intellij.openapi.vfs.VirtualFile
+
+class ObjJProblemFileHighlighterFilter : Condition<VirtualFile> {
+    override fun value(virtualFile: VirtualFile): Boolean {
+        val fileType = virtualFile.fileType
+        return fileType === ObjJFileType.INSTANCE
+    }
+}


### PR DESCRIPTION
Added plugin ability to mark files as having errors in the project files view side bar.
__Note*__ this only works for files that have been opened and processed by the syntax highlighter