### PR TITLE
Fixed: Error on "@deref" expression statements

### DIFF
--- a/resources/grammar/ObjJ.bnf
+++ b/resources/grammar/ObjJ.bnf
@@ -1497,6 +1497,7 @@ leftExpr
     |	methodCall
     | 	'new' expr ('(' expressionSequence? ')')?
 	|	variableAssignmentLogical
+	|	'@deref' '(' variableName ')'
     |	qualifiedReference
     |	objectLiterals
     |	primary


### PR DESCRIPTION
`@deref()` expression was not implemented in parser as a valid value to assign to a variable. Grammar was changed to allow this as a valid expression