### PR TITLE
Fixed: Return statement annotator incorrectly flagging void method return statements

### DIFF
--- a/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJAccessorPropertyPsiUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJAccessorPropertyPsiUtil.kt
@@ -15,7 +15,7 @@ import java.util.*
  * @return accessor property var type
  */
 fun getVarType(accessorProperty:ObjJAccessorProperty): String? =
-    accessorProperty.stub.varType ?: accessorProperty.getParentOfType(ObjJInstanceVariableDeclaration::class.java)?.formalVariableType?.text
+    accessorProperty.stub?.varType ?: accessorProperty.getParentOfType(ObjJInstanceVariableDeclaration::class.java)?.formalVariableType?.text
 
 /**
  * Tests whether an accessor property is a getter or not


### PR DESCRIPTION
Some methods with return type `void`, return method calls to methods that also return `void`. Annotator now takes this into account, and does not mark these return statements as returning a value, when they do not.