### PR TITLE
Fixed: Variable name resolutions when resolution returns null

### DIFF
--- a/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJBlockPsiUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJBlockPsiUtil.kt
@@ -6,11 +6,8 @@ import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJBlock
 import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJFunctionDeclarationElement
 import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJHasBlockStatement
 import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJHasBlockStatements
-import cappuccino.ide.intellij.plugin.utils.ArrayUtils
 import cappuccino.ide.intellij.plugin.utils.Filter
-import com.google.common.collect.Lists
 import java.util.*
-import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.collections.ArrayList
 
@@ -170,11 +167,12 @@ private fun <T : PsiElement> ObjJBlock?.getBlockChildrenOfType(
                 }
             }
             if (!this.isEquivalentTo(block) && recursive) {
-                out.addAll(block.getBlockChildrenOfType(aClass, recursive,filter,returnFirst,offset))
+                out.addAll(block.getBlockChildrenOfType(aClass, recursive, filter,returnFirst,offset))
+
             }
         }
         currentBlocks = nextBlocks
-    } while (!currentBlocks.isEmpty())
+    } while (currentBlocks.isNotEmpty())
     return out
 }
 
@@ -185,7 +183,6 @@ private fun getBlocksBlocks(block:ObjJBlock) : List<ObjJBlock> {
     }
     return out
 }
-
 
 fun <T : PsiElement> PsiElement.getParentBlockChildrenOfType(aClass: Class<T>, recursive: Boolean): List<T> {
     var block: ObjJBlock? = getParentOfType(ObjJBlock::class.java) ?: return emptyList()

--- a/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJVariableNameResolveUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJVariableNameResolveUtil.kt
@@ -52,7 +52,7 @@ object ObjJVariableNameResolveUtil {
         if (variableNameElement.indexInQualifiedReference > 0) {
             return ObjJVariableNameUtil.resolveQualifiedReferenceVariable(variableNameElement)
         }
-        return ObjJVariableNameUtil.getSiblingVariableAssignmentNameElement(variableNameElement, 0) { `var` -> isPrecedingVar(variableNameElement, `var`) }
+        return ObjJVariableNameUtil.getSiblingVariableAssignmentNameElement(variableNameElement, 0) { `var` -> isPrecedingVar(variableNameElement, `var`) } ?: variableNameElement
 
     }
 

--- a/src/cappuccino/ide/intellij/plugin/utils/ObjJFileUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/utils/ObjJFileUtil.kt
@@ -134,3 +134,20 @@ class ObjJFileUtil {
     }
 
 }
+
+infix fun PsiElement?.notInSameFile(otherElement:PsiElement?) : Boolean {
+    return !sharesSameFile(this, otherElement)
+}
+infix fun PsiElement?.inSameFile(otherElement:PsiElement?) : Boolean {
+    return sharesSameFile(this, otherElement)
+}
+
+fun PsiElement?.sharesFile(otherElement:PsiElement?) : Boolean {
+    return sharesSameFile(this, otherElement)
+}
+
+fun sharesSameFile(element1:PsiElement?, element2:PsiElement?) : Boolean {
+    val file1 = element1?.containingFile ?: return false
+    val file2 = element2?.containingFile ?: return false
+    return file1.isEquivalentTo(file2) && file1.virtualFile.path == file2.virtualFile.path
+}


### PR DESCRIPTION
When variable name resolution resolution returned null, Intellij seemed to decide on a random instance of this variable. Still not sure how it occurred. Fixed it by returning self if no declaration was found.