### PR TITLE
Simple method caller resolution

### DIFF
--- a/src/cappuccino/ide/intellij/plugin/annotator/ObjJImplementationDeclarationAnnotatorUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/annotator/ObjJImplementationDeclarationAnnotatorUtil.kt
@@ -58,7 +58,7 @@ internal object ObjJImplementationDeclarationAnnotatorUtil {
             val unimplementedMethods = declaration.getUnimplementedProtocolMethods(protocolName)
             if (!unimplementedMethods.required.isEmpty()) {
                 annotationHolder.createErrorAnnotation(className, "Missing required protocol methods")
-                        .registerFix(ObjJMissingProtocolMethodFix(declaration, protocolName, unimplementedMethods))
+                        .registerFix(ObjJMissingProtocolMethodFix(unimplementedMethods))
             }
         }
     }

--- a/src/cappuccino/ide/intellij/plugin/annotator/ObjJImplementationDeclarationAnnotatorUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/annotator/ObjJImplementationDeclarationAnnotatorUtil.kt
@@ -58,7 +58,7 @@ internal object ObjJImplementationDeclarationAnnotatorUtil {
             val unimplementedMethods = declaration.getUnimplementedProtocolMethods(protocolName)
             if (!unimplementedMethods.required.isEmpty()) {
                 annotationHolder.createErrorAnnotation(className, "Missing required protocol methods")
-                        .registerFix(ObjJMissingProtocolMethodFix(unimplementedMethods))
+                        .registerFix(ObjJMissingProtocolMethodFix(declaration, protocolName, unimplementedMethods))
             }
         }
     }

--- a/src/cappuccino/ide/intellij/plugin/annotator/ObjJMethodCallAnnotatorUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/annotator/ObjJMethodCallAnnotatorUtil.kt
@@ -40,7 +40,7 @@ internal object ObjJMethodCallAnnotatorUtil {
         //Check that call target for method call is valid
         //Only used is setting for validate call target is set.
         if (ObjJPluginSettings.validateCallTarget()) {// && !IgnoreUtil.shouldIgnore(methodCall, ElementType.CALL_TARGET)) {
-            validateCallTarget(methodCall, holder)
+            //validateCallTarget(methodCall, holder)
         }
     }
 

--- a/src/cappuccino/ide/intellij/plugin/contributor/BlanketCompletionProvider.kt
+++ b/src/cappuccino/ide/intellij/plugin/contributor/BlanketCompletionProvider.kt
@@ -18,7 +18,6 @@ import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJClassDeclarationElement
 import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJMethodHeaderDeclaration
 import cappuccino.ide.intellij.plugin.psi.types.ObjJClassType.Companion.PRIMITIVE_VAR_NAMES
 import cappuccino.ide.intellij.plugin.psi.types.ObjJTokenSets
-import cappuccino.ide.intellij.plugin.psi.types.ObjJTokenType
 import cappuccino.ide.intellij.plugin.psi.types.ObjJTypes
 import cappuccino.ide.intellij.plugin.psi.utils.*
 import cappuccino.ide.intellij.plugin.utils.ArrayUtils
@@ -29,7 +28,6 @@ import java.util.logging.Logger
 
 import cappuccino.ide.intellij.plugin.utils.ArrayUtils.EMPTY_STRING_ARRAY
 import cappuccino.ide.intellij.plugin.utils.EditorUtil
-import java.util.logging.Level
 
 class BlanketCompletionProvider : CompletionProvider<CompletionParameters>() {
 
@@ -44,22 +42,24 @@ class BlanketCompletionProvider : CompletionProvider<CompletionParameters>() {
         val queryString = element.text.substring(0, element.text.indexOf(CARET_INDICATOR))
 
         if (element.getElementType() in ObjJTokenSets.COMMENTS) {
-            LOGGER.info("Item is in comment")
             val text = element.text
             if (!text.contains("@var")) {
                 resultSet.stopHere()
                 return
             }
-            val preText = text.substringBefore(CARET_INDICATOR, "").split("\\s+")
+            val commentText = text.substringBefore(CARET_INDICATOR, "")
+            val commentTokenParts:List<String> = commentText.split("\\s+".toRegex())
             var afterVar = false
             var indexAfter = -1
-            for(part in preText) {
+            for (part in commentTokenParts) {
                 if (part == "@var") {
                     afterVar = true;
                     continue
                 }
-                if (!afterVar) continue
-               indexAfter++
+                if (!afterVar) {
+                    continue
+                }
+                indexAfter++
                 if (indexAfter == 0) {
                     getClassNameCompletions(resultSet, element)
                 } else if (indexAfter == 1) {
@@ -173,7 +173,7 @@ class BlanketCompletionProvider : CompletionProvider<CompletionParameters>() {
         if (element == null) {
             return
         }
-        if (element.hasParentOfType(ObjJInheritedProtocolList::class.java) || element.hasParentOfType(ObjJFormalVariableType::class.java)) {
+        if (element.hasParentOfType(ObjJInheritedProtocolList::class.java) || element.hasParentOfType(ObjJFormalVariableType::class.java) || element.getElementType() in ObjJTokenSets.COMMENTS) {
             ObjJProtocolDeclarationsIndex.instance.getAllKeys(element.project).forEach {
                 resultSet.addElement(LookupElementBuilder.create(it).withInsertHandler(ObjJClassNameInsertHandler.instance))
             }
@@ -183,7 +183,7 @@ class BlanketCompletionProvider : CompletionProvider<CompletionParameters>() {
                 resultSet.addElement(LookupElementBuilder.create(it).withInsertHandler(ObjJClassNameInsertHandler.instance))
             }
         }
-        if(element.hasParentOfType( ObjJCallTarget::class.java) || element.hasParentOfType(ObjJFormalVariableType::class.java)) {
+        if(element.hasParentOfType( ObjJCallTarget::class.java) || element.hasParentOfType(ObjJFormalVariableType::class.java) || element.getElementType() in ObjJTokenSets.COMMENTS) {
             ObjJImplementationDeclarationsIndex.instance.getAllKeys(element.project).forEach{
                 resultSet.addElement(LookupElementBuilder.create(it).withInsertHandler(ObjJClassNameInsertHandler.instance))
             }

--- a/src/cappuccino/ide/intellij/plugin/contributor/ObjJMethodCallCompletionContributor2.kt
+++ b/src/cappuccino/ide/intellij/plugin/contributor/ObjJMethodCallCompletionContributor2.kt
@@ -98,7 +98,7 @@ object ObjJMethodCallCompletionContributor2 {
             if (!inScope(targetScope, methodHeader)){ continue }
             //Get the selector at index, or continue loop
             val selector: ObjJSelector = getSelectorAtIndex(methodHeader, selectorIndex) ?: continue
-            if (possibleContainingClassNames.size == 1 && possibleContainingClassNames[0] != ObjJClassType.UNDETERMINED) {
+            if (ObjJClassType.UNDETERMINED !in possibleContainingClassNames) {
                 if (methodHeader.containingClassName != possibleContainingClassNames[0]) {
                     continue
                 }
@@ -196,16 +196,19 @@ object ObjJMethodCallCompletionContributor2 {
         if (instanceVariableDeclaration.variableName == null) {
             return
         }
+        val containingClass = instanceVariableDeclaration.containingClassName
+        if (ObjJClassType.UNDETERMINED !in possibleContainingClassNames && containingClass !in possibleContainingClassNames) {
+            return
+        }
         //ProgressIndicatorProvider.checkCanceled();
-        val priority = if (possibleContainingClassNames.contains(instanceVariableDeclaration.containingClassName))
+        val priority = if (possibleContainingClassNames.contains(containingClass))
             ObjJCompletionContributor.TARGETTED_INSTANCE_VAR_SUGGESTION_PRIORITY
         else
             ObjJCompletionContributor.GENERIC_INSTANCE_VARIABLE_SUGGESTION_PRIORITY
 
-        val className = instanceVariableDeclaration.containingClassName
         val variableName = instanceVariableDeclaration.variableName!!.name
         val variableType = instanceVariableDeclaration.formalVariableType.text
-        ObjJSelectorLookupUtil.addSelectorLookupElement(result, variableName, className, "<$variableType>", priority, false, ObjJIcons.VARIABLE_ICON)
+        ObjJSelectorLookupUtil.addSelectorLookupElement(result, variableName, containingClass, "<$variableType>", priority, false, ObjJIcons.VARIABLE_ICON)
     }
 
 
@@ -216,6 +219,10 @@ object ObjJMethodCallCompletionContributor2 {
     private fun addInstanceVariableAccessorMethods(result: CompletionResultSet, possibleContainingClassNames:List<String>, instanceVariable: ObjJInstanceVariableDeclaration) {
         //Get className
         val className = instanceVariable.containingClassName
+
+        if (ObjJClassType.UNDETERMINED !in possibleContainingClassNames && className !in possibleContainingClassNames) {
+            return
+        }
 
         //Find completion contribution list priority
         val priority:Double = getPriority(possibleContainingClassNames, className, TARGETTED_METHOD_SUGGESTION_PRIORITY,GENERIC_METHOD_SUGGESTION_PRIORITY)

--- a/src/cappuccino/ide/intellij/plugin/contributor/ObjJMethodCallCompletionContributor2.kt
+++ b/src/cappuccino/ide/intellij/plugin/contributor/ObjJMethodCallCompletionContributor2.kt
@@ -10,6 +10,7 @@ import cappuccino.ide.intellij.plugin.indices.ObjJUnifiedMethodIndex
 import cappuccino.ide.intellij.plugin.lang.ObjJIcons
 import cappuccino.ide.intellij.plugin.psi.*
 import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJMethodHeaderDeclaration
+import cappuccino.ide.intellij.plugin.psi.types.ObjJClassType
 import cappuccino.ide.intellij.plugin.psi.utils.*
 import cappuccino.ide.intellij.plugin.references.ObjJSelectorReferenceResolveUtil
 import cappuccino.ide.intellij.plugin.utils.ObjJInheritanceUtil
@@ -18,6 +19,7 @@ import com.intellij.openapi.progress.ProgressIndicatorProvider
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -71,7 +73,7 @@ object ObjJMethodCallCompletionContributor2 {
             else -> emptyList()
         }
         //Add actual method call completions
-        addMethodDeclarationLookupElements(psiElement.project, result, possibleContainingClassNames, scope, selectorString, selectorIndex)
+        addMethodDeclarationLookupElements(psiElement.project, psiElement.containingFile?.name, result, possibleContainingClassNames, scope, selectorString, selectorIndex)
 
         val hasLocalScope:Boolean = (scope == TargetScope.INSTANCE || scope == TargetScope.ANY)
         // Add accessor and instance variable elements if selector size is equal to one
@@ -81,8 +83,10 @@ object ObjJMethodCallCompletionContributor2 {
         }
     }
 
-    private fun addMethodDeclarationLookupElements(project:Project, result:CompletionResultSet, possibleContainingClassNames: List<String>, targetScope: TargetScope, selectorString: String, selectorIndex:Int) {
-        val methodHeaders: List<ObjJMethodHeaderDeclaration<*>> = ObjJUnifiedMethodIndex.instance.getByPatternFlat(selectorString.replace(CARET_INDICATOR, "(.*)"), project)
+    private fun addMethodDeclarationLookupElements(project:Project, fileName:String?, result:CompletionResultSet, possibleContainingClassNames: List<String>, targetScope: TargetScope, selectorString: String, selectorIndex:Int) {
+        val methodHeaders: List<ObjJMethodHeaderDeclaration<*>> = ObjJUnifiedMethodIndex.instance
+                .getByPatternFlat(selectorString.replace(CARET_INDICATOR, "(.*)"), project)
+                .filter { !(it.stub?.ignored ?: CommentParserUtil.isIgnored(it) || CommentParserUtil.isIgnored(it.parent)) && (!it.containingClassName.startsWith("_") || it.containingFile?.name == fileName) }
         if (methodHeaders.isEmpty()) {
             return
         }
@@ -94,6 +98,11 @@ object ObjJMethodCallCompletionContributor2 {
             if (!inScope(targetScope, methodHeader)){ continue }
             //Get the selector at index, or continue loop
             val selector: ObjJSelector = getSelectorAtIndex(methodHeader, selectorIndex) ?: continue
+            if (possibleContainingClassNames.size == 1 && possibleContainingClassNames[0] != ObjJClassType.UNDETERMINED) {
+                if (methodHeader.containingClassName != possibleContainingClassNames[0]) {
+                    continue
+                }
+            }
             //Determine the priority
             val priority:Double = getPriority(possibleContainingClassNames, selector.containingClassName, TARGETTED_METHOD_SUGGESTION_PRIORITY, GENERIC_METHOD_SUGGESTION_PRIORITY)
             //Add the lookup element

--- a/src/cappuccino/ide/intellij/plugin/contributor/ObjJMethodCallCompletionContributorUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/contributor/ObjJMethodCallCompletionContributorUtil.kt
@@ -113,13 +113,23 @@ object ObjJMethodCallCompletionContributorUtil {
         // and create selector elements for later use.
         val orphanedSelectors = psiElement.parent.getChildrenOfType(ObjJTypes.ObjJ_ID)
         for (subSelector in orphanedSelectors) {
-            if (subSelector.text.isEmpty()) {
+            val selectorText = subSelector.text.replace("[^a-zA-Z_]".toRegex(), "").trim()
+            if (selectorText.isEmpty()) {
                 continue
             }
-            selectors.add(++selectorIndex, ObjJElementFactory.createSelector(project, subSelector.text.replace("\\s+".toRegex(), "")))
+
+            selectors.add(++selectorIndex, ObjJElementFactory.createSelector(project, selectorText)!!)
         }
         //Finally add the current psi element as a selector
-        selectors.add(ObjJElementFactory.createSelector(project, psiElement.text.replace("\\s+".toRegex(), "")))
+        try {
+            val selectorString = psiElement.text.replace("[^a-zA-Z_]".toRegex(), "").trim()
+            if (selectorString.isNotEmpty()) {
+                val selector = ObjJElementFactory.createSelector(project, selectorString)
+                if (selector != null) {
+                    selectors.add(selector)
+                }
+            }
+        } catch (e:Exception) {}
         return selectors
     }
 

--- a/src/cappuccino/ide/intellij/plugin/fixes/ObjJMissingProtocolMethodFix.kt
+++ b/src/cappuccino/ide/intellij/plugin/fixes/ObjJMissingProtocolMethodFix.kt
@@ -1,29 +1,24 @@
 package cappuccino.ide.intellij.plugin.fixes
 
 import cappuccino.ide.intellij.plugin.inspections.ObjJInspectionProvider
-import cappuccino.ide.intellij.plugin.psi.ObjJElementFactory
-import cappuccino.ide.intellij.plugin.psi.ObjJImplementationDeclaration
 import com.intellij.codeInsight.intention.impl.BaseIntentionAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import com.intellij.util.IncorrectOperationException
+import cappuccino.ide.intellij.plugin.psi.ObjJMethodHeader
 import cappuccino.ide.intellij.plugin.psi.utils.ObjJProtocolDeclarationPsiUtil.ProtocolMethods
-import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
-import com.intellij.openapi.editor.Document
-import com.intellij.openapi.ui.Messages
-import com.intellij.psi.PsiElement
-import java.util.logging.Logger
-import javax.swing.SwingUtilities
+import org.jetbrains.annotations.Nls
 
-class ObjJMissingProtocolMethodFix(private val declaration:ObjJImplementationDeclaration, private val protocolName:String, private val methodHeaders: ProtocolMethods) : BaseIntentionAction() {
+class ObjJMissingProtocolMethodFix(private val methodHeaders: ProtocolMethods) : BaseIntentionAction() {
 
     override fun getText(): String {
         return "Implement missing protocol methodHeaders"
     }
 
     override fun getFamilyName(): String {
-        return ObjJInspectionProvider.GROUP_DISPLAY_NAME
+        return ObjJInspectionProvider.GROUP_DISPLAY_NAME;
     }
 
     override fun isAvailable(
@@ -34,84 +29,11 @@ class ObjJMissingProtocolMethodFix(private val declaration:ObjJImplementationDec
     @Throws(IncorrectOperationException::class)
     override fun invoke(
             project: Project, editor: Editor, psiFile: PsiFile) {
-        try {
-            addMethods(project, editor.document)
-        } catch (e:Exception) {
-            SwingUtilities.invokeLater {
-                Messages.showDialog(project, MESSAGE.format(protocolName, "An unexpected error occurred"), TITLE, listOf("OK").toTypedArray(), 0, Messages.getWarningIcon())
-            }
-            Logger.getLogger(ObjJMissingProtocolMethodFix::class.java.canonicalName).severe(MESSAGE.format(protocolName, "An unexpected error occurred") + "; Error: "+e.message)
-        }
-        DaemonCodeAnalyzer.getInstance(declaration.project).restart(declaration.containingFile)
+
     }
 
-    private fun addMethods(project: Project, document:Document) {
-        if (methodHeaders.required.isEmpty()) {
-            return
-        }
-        val before:Boolean
-        val sibling:PsiElement? = when {
-            declaration.methodDeclarationList.isNotEmpty() -> {
-                before = false
-                val decList = declaration.methodDeclarationList
-                decList.sortByDescending { it.textRange.endOffset }
-                decList.first()
-            }
-            declaration.atEnd != null -> {
-                before = true
-                declaration.atEnd!!
-            }
-            declaration.inheritedProtocolList != null -> {
-                before = false
-                declaration.inheritedProtocolList!!
-            }
-            declaration.lastChild != null -> {
-                before = true
-                declaration.lastChild
-            }
-            else -> {
-                before = true
-                declaration.node.treeNext?.psi
-            }
-        }
-        if (sibling == null) {
-            SwingUtilities.invokeLater {
-                Messages.showDialog(project, MESSAGE.format(protocolName, "Declaration is not well formed"), TITLE, listOf("OK").toTypedArray(), 0, Messages.getWarningIcon())
-            }
-            return
-        }
+    private fun addMethods(project: Project, file: VirtualFile, methodHeaders: List<ObjJMethodHeader>) {
 
-        var lastMethod:PsiElement? = null
-        for(methodHeader in methodHeaders.required) {
-            val method = ObjJElementFactory.createMethodDeclaration(project, methodHeader)
-            if (lastMethod == null) {
-                if (before) {
-                    declaration.addBefore(method, sibling)
-                } else {
-                    declaration.addAfter(method, sibling)
-                }
-            } else {
-                declaration.addAfter(method,lastMethod)
-            }
-            document.insertString(method.textRange.endOffset, "\n\n")
-            lastMethod = method
-        }
-    }
 
-    companion object {
-        const val TITLE = "Protocol Implementation Failure"
-        const val MESSAGE:String = "Failed to create placeholder methods for protocol %s. %s"
-
-        private fun numberOfReturnsNeeded(element:PsiElement, before:Boolean, required:Int) : Int {
-            var remaining = required;
-            var prevSibling:PsiElement = element.prevSibling ?: return required
-            for (i in 0 until required) {
-                if (prevSibling.text?.endsWith("\n") == true) {
-                    remaining -= 1;
-                }
-                prevSibling = prevSibling.prevSibling ?: return remaining
-            }
-            return remaining
-        }
     }
 }

--- a/src/cappuccino/ide/intellij/plugin/fixes/ObjJMissingProtocolMethodFix.kt
+++ b/src/cappuccino/ide/intellij/plugin/fixes/ObjJMissingProtocolMethodFix.kt
@@ -1,24 +1,29 @@
 package cappuccino.ide.intellij.plugin.fixes
 
 import cappuccino.ide.intellij.plugin.inspections.ObjJInspectionProvider
+import cappuccino.ide.intellij.plugin.psi.ObjJElementFactory
+import cappuccino.ide.intellij.plugin.psi.ObjJImplementationDeclaration
 import com.intellij.codeInsight.intention.impl.BaseIntentionAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import com.intellij.util.IncorrectOperationException
-import cappuccino.ide.intellij.plugin.psi.ObjJMethodHeader
 import cappuccino.ide.intellij.plugin.psi.utils.ObjJProtocolDeclarationPsiUtil.ProtocolMethods
-import org.jetbrains.annotations.Nls
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.ui.Messages
+import com.intellij.psi.PsiElement
+import java.util.logging.Logger
+import javax.swing.SwingUtilities
 
-class ObjJMissingProtocolMethodFix(private val methodHeaders: ProtocolMethods) : BaseIntentionAction() {
+class ObjJMissingProtocolMethodFix(private val declaration:ObjJImplementationDeclaration, private val protocolName:String, private val methodHeaders: ProtocolMethods) : BaseIntentionAction() {
 
     override fun getText(): String {
         return "Implement missing protocol methodHeaders"
     }
 
     override fun getFamilyName(): String {
-        return ObjJInspectionProvider.GROUP_DISPLAY_NAME;
+        return ObjJInspectionProvider.GROUP_DISPLAY_NAME
     }
 
     override fun isAvailable(
@@ -29,11 +34,84 @@ class ObjJMissingProtocolMethodFix(private val methodHeaders: ProtocolMethods) :
     @Throws(IncorrectOperationException::class)
     override fun invoke(
             project: Project, editor: Editor, psiFile: PsiFile) {
-
+        try {
+            addMethods(project, editor.document)
+        } catch (e:Exception) {
+            SwingUtilities.invokeLater {
+                Messages.showDialog(project, MESSAGE.format(protocolName, "An unexpected error occurred"), TITLE, listOf("OK").toTypedArray(), 0, Messages.getWarningIcon())
+            }
+            Logger.getLogger(ObjJMissingProtocolMethodFix::class.java.canonicalName).severe(MESSAGE.format(protocolName, "An unexpected error occurred") + "; Error: "+e.message)
+        }
+        DaemonCodeAnalyzer.getInstance(declaration.project).restart(declaration.containingFile)
     }
 
-    private fun addMethods(project: Project, file: VirtualFile, methodHeaders: List<ObjJMethodHeader>) {
+    private fun addMethods(project: Project, document:Document) {
+        if (methodHeaders.required.isEmpty()) {
+            return
+        }
+        val before:Boolean
+        val sibling:PsiElement? = when {
+            declaration.methodDeclarationList.isNotEmpty() -> {
+                before = false
+                val decList = declaration.methodDeclarationList
+                decList.sortByDescending { it.textRange.endOffset }
+                decList.first()
+            }
+            declaration.atEnd != null -> {
+                before = true
+                declaration.atEnd!!
+            }
+            declaration.inheritedProtocolList != null -> {
+                before = false
+                declaration.inheritedProtocolList!!
+            }
+            declaration.lastChild != null -> {
+                before = true
+                declaration.lastChild
+            }
+            else -> {
+                before = true
+                declaration.node.treeNext?.psi
+            }
+        }
+        if (sibling == null) {
+            SwingUtilities.invokeLater {
+                Messages.showDialog(project, MESSAGE.format(protocolName, "Declaration is not well formed"), TITLE, listOf("OK").toTypedArray(), 0, Messages.getWarningIcon())
+            }
+            return
+        }
 
+        var lastMethod:PsiElement? = null
+        for(methodHeader in methodHeaders.required) {
+            val method = ObjJElementFactory.createMethodDeclaration(project, methodHeader)
+            if (lastMethod == null) {
+                if (before) {
+                    declaration.addBefore(method, sibling)
+                } else {
+                    declaration.addAfter(method, sibling)
+                }
+            } else {
+                declaration.addAfter(method,lastMethod)
+            }
+            document.insertString(method.textRange.endOffset, "\n\n")
+            lastMethod = method
+        }
+    }
 
+    companion object {
+        const val TITLE = "Protocol Implementation Failure"
+        const val MESSAGE:String = "Failed to create placeholder methods for protocol %s. %s"
+
+        private fun numberOfReturnsNeeded(element:PsiElement, before:Boolean, required:Int) : Int {
+            var remaining = required;
+            var prevSibling:PsiElement = element.prevSibling ?: return required
+            for (i in 0 until required) {
+                if (prevSibling.text?.endsWith("\n") == true) {
+                    remaining -= 1;
+                }
+                prevSibling = prevSibling.prevSibling ?: return remaining
+            }
+            return remaining
+        }
     }
 }

--- a/src/cappuccino/ide/intellij/plugin/indices/ObjJMethodFragmentIndex.kt
+++ b/src/cappuccino/ide/intellij/plugin/indices/ObjJMethodFragmentIndex.kt
@@ -19,6 +19,6 @@ class ObjJMethodFragmentIndex private constructor() : ObjJStringStubIndexBase<Ob
     companion object {
         val instance = ObjJMethodFragmentIndex()
         val KEY: StubIndexKey<String, ObjJMethodHeaderDeclaration<*>> = IndexKeyUtil.createIndexKey<String, ObjJMethodHeaderDeclaration<*>>(ObjJMethodFragmentIndex::class.java)
-        private val VERSION = 0
+        private val VERSION = 1
     }
 }

--- a/src/cappuccino/ide/intellij/plugin/indices/ObjJMethodHeaderDeclarationsIndexBase.kt
+++ b/src/cappuccino/ide/intellij/plugin/indices/ObjJMethodHeaderDeclarationsIndexBase.kt
@@ -82,7 +82,7 @@ abstract class ObjJMethodHeaderDeclarationsIndexBase<MethodHeaderT : ObjJMethodH
     companion object {
 
         private val LOGGER = Logger.getLogger(ObjJMethodHeaderDeclarationsIndexBase::class.java.canonicalName)
-        private val VERSION = 1
+        private val VERSION = 2
         private val PARTS_PATTERN = Pattern.compile("([a-z]*)?([A-Z0-9][a-z]*)*")
 
         private fun getParts(parts: String?): List<String> {

--- a/src/cappuccino/ide/intellij/plugin/indices/ObjJMethodIndex.kt
+++ b/src/cappuccino/ide/intellij/plugin/indices/ObjJMethodIndex.kt
@@ -27,6 +27,6 @@ class ObjJMethodIndex private constructor() : ObjJStringStubIndexBase<ObjJMethod
     companion object {
         val KEY = IndexKeyUtil.createIndexKey(ObjJMethodIndex::class.java)
         val instance = ObjJMethodIndex()
-        private val VERSION = 1
+        private val VERSION = 2
     }
 }

--- a/src/cappuccino/ide/intellij/plugin/indices/ObjJSelectorInferredMethodIndex.kt
+++ b/src/cappuccino/ide/intellij/plugin/indices/ObjJSelectorInferredMethodIndex.kt
@@ -27,6 +27,6 @@ class ObjJSelectorInferredMethodIndex : ObjJMethodHeaderDeclarationsIndexBase<Ob
     companion object {
         val instance = ObjJSelectorInferredMethodIndex()
         private val KEY = IndexKeyUtil.createIndexKey(ObjJSelectorInferredMethodIndex::class.java)
-        private val VERSION = 1
+        private val VERSION = 2
     }
 }

--- a/src/cappuccino/ide/intellij/plugin/indices/ObjJUnifiedMethodIndex.kt
+++ b/src/cappuccino/ide/intellij/plugin/indices/ObjJUnifiedMethodIndex.kt
@@ -19,6 +19,6 @@ class ObjJUnifiedMethodIndex private constructor() : ObjJMethodHeaderDeclaration
     companion object {
         val KEY: StubIndexKey<String, ObjJMethodHeaderDeclaration<*>> = IndexKeyUtil.createIndexKey<String, ObjJMethodHeaderDeclaration<*>>(ObjJUnifiedMethodIndex::class.java)
         val instance = ObjJUnifiedMethodIndex()
-        private val VERSION = 1
+        private val VERSION = 2
     }
 }

--- a/src/cappuccino/ide/intellij/plugin/inspections/ObjJMethodReturnsAValueInspection.kt
+++ b/src/cappuccino/ide/intellij/plugin/inspections/ObjJMethodReturnsAValueInspection.kt
@@ -7,6 +7,8 @@ import cappuccino.ide.intellij.plugin.psi.ObjJVisitor
 import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJBlock
 import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJFunctionDeclarationElement
 import cappuccino.ide.intellij.plugin.psi.types.ObjJClassType
+import cappuccino.ide.intellij.plugin.psi.utils.CommentParserUtil
+import cappuccino.ide.intellij.plugin.psi.utils.IgnoreFlags
 import cappuccino.ide.intellij.plugin.psi.utils.getBlockChildrenOfType
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemsHolder
@@ -35,6 +37,9 @@ class ObjJMethodReturnsAValueInspection : LocalInspectionTool() {
     companion object {
 
         private fun validateMethodReturn(methodDeclaration: ObjJMethodDeclaration, problemsHolder: ProblemsHolder) {
+            if (CommentParserUtil.isIgnored(methodDeclaration, IgnoreFlags.IGNORE_RETURN, true)) {
+                return
+            }
             val returnType = methodDeclaration.methodHeader.returnType
             if (returnType == ObjJClassType.VOID_CLASS_NAME) {
                 return

--- a/src/cappuccino/ide/intellij/plugin/inspections/ObjJReturnStatementDisagreementInspection.kt
+++ b/src/cappuccino/ide/intellij/plugin/inspections/ObjJReturnStatementDisagreementInspection.kt
@@ -7,6 +7,8 @@ import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJCompositeElement
 import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJFunctionDeclarationElement
 import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJMethodHeaderDeclaration
 import cappuccino.ide.intellij.plugin.psi.types.ObjJClassType
+import cappuccino.ide.intellij.plugin.psi.utils.CommentParserUtil
+import cappuccino.ide.intellij.plugin.psi.utils.IgnoreFlags
 import cappuccino.ide.intellij.plugin.psi.utils.getBlockChildrenOfType
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemHighlightType
@@ -35,6 +37,9 @@ class ObjJReturnStatementDisagreementInspection : LocalInspectionTool() {
     companion object {
 
         private fun validateBlockReturnStatements(block: ObjJBlock, problemsHolder: ProblemsHolder) {
+            if (CommentParserUtil.isIgnored(block, IgnoreFlags.IGNORE_RETURN, true)) {
+                return
+            }
             val returnStatementsList = block.getBlockChildrenOfType(ObjJReturnStatement::class.java, true)
             if (returnStatementsList.isEmpty()) {
                 return

--- a/src/cappuccino/ide/intellij/plugin/lang/ObjJFile.kt
+++ b/src/cappuccino/ide/intellij/plugin/lang/ObjJFile.kt
@@ -1,5 +1,6 @@
 package cappuccino.ide.intellij.plugin.lang
 
+import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJBlock
 import cappuccino.ide.intellij.plugin.structure.ObjJStructureViewElement
 import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.openapi.fileTypes.FileType
@@ -10,6 +11,7 @@ import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJClassDeclarationElement
 import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJCompositeElement
 import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJHasTreeStructureElement
 import cappuccino.ide.intellij.plugin.psi.utils.ObjJFilePsiUtil
+import cappuccino.ide.intellij.plugin.psi.utils.getBlockChildrenOfType
 import cappuccino.ide.intellij.plugin.utils.ObjJFileUtil
 import com.intellij.ide.projectView.PresentationData
 
@@ -41,6 +43,18 @@ class ObjJFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, ObjJL
 
     override fun <PsiT : PsiElement> getChildrenOfType(childClass: Class<PsiT>): List<PsiT> =
             PsiTreeUtil.getChildrenOfTypeAsList(this, childClass)
+
+    fun <PsiT:PsiElement> getFileChildrenOfType(aClass: Class<PsiT>, recursive: Boolean): List<PsiT> {
+        val children = getChildrenOfType(aClass).toMutableList()
+        if (!recursive) {
+            return children
+        }
+        val blockChildren = getChildrenOfType(ObjJBlock::class.java).flatMap {
+            it.getBlockChildrenOfType(aClass, true)
+        }
+        children.addAll(blockChildren)
+        return children
+    }
 
     override fun <PsiT : PsiElement> getParentOfType(parentClass: Class<PsiT>): PsiT? =
             PsiTreeUtil.getParentOfType(this, parentClass)

--- a/src/cappuccino/ide/intellij/plugin/psi/ObjJElementFactory.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/ObjJElementFactory.kt
@@ -21,10 +21,11 @@ object ObjJElementFactory {
         return createFileFromText(project, scriptText).classDeclarations[0].getClassName()
     }
 
-    fun createSelector(project: Project, selector: String): ObjJSelector {
+    fun createSelector(project: Project, selector: String): ObjJSelector?
+    {   val selector = selector.replace("[^a-zA-Z_]".toRegex(), "").trim()
         val scriptText = "@implementation $PlaceholderClassName \n - (void) $selector{} @end"
         val implementationDeclaration = createFileFromText(project, scriptText).classDeclarations[0] as ObjJImplementationDeclaration
-        return implementationDeclaration.methodDeclarationList[0].methodHeader.selectorList[0]
+        return implementationDeclaration.methodDeclarationList.get(0)?.methodHeader?.selectorList?.get(0)
     }
 
     fun createVariableName(project: Project, variableName: String): ObjJVariableName {

--- a/src/cappuccino/ide/intellij/plugin/psi/ObjJElementFactory.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/ObjJElementFactory.kt
@@ -49,12 +49,6 @@ object ObjJElementFactory {
         return file.firstChild
     }
 
-    fun createNewLine(project: Project): PsiElement {
-        val scriptText = "\n"
-        val file = createFileFromText(project, scriptText)
-        return file.firstChild
-    }
-
     fun createSemiColonErrorElement(project: Project): PsiErrorElement? {
         val scriptText = "?*__ERR_SEMICOLON__*?"
         val file = createFileFromText(project, scriptText)
@@ -71,7 +65,7 @@ object ObjJElementFactory {
     }
 
     fun createIgnoreComment(project: Project, elementType: IgnoreUtil.ElementType): ObjJComment {
-        val scriptText = "// @ignore " + elementType.type
+        val scriptText = "//ignore " + elementType.type
         val file = createFileFromText(project, scriptText)
         return file.getChildOfType(ObjJComment::class.java)!!
     }
@@ -80,27 +74,25 @@ object ObjJElementFactory {
         return PsiFileFactory.getInstance(project).createFileFromText("dummy.j", ObjJLanguage.instance, text) as ObjJFile
     }
 
-    fun createMethodDeclaration(project: Project, methodHeader: ObjJMethodHeader): ObjJMethodDeclaration {
-        val script ="""
-                @implementation ${PlaceholderClassName}
-                ${methodHeader.text}
-                {
-                    //@todo provide implementation
-                    ${getDefaultReturnValueString(methodHeader.methodHeaderReturnTypeElement)};
-                }
-                @end""".trimIndent()
+    private fun createMethodDeclaration(project: Project, methodHeader: ObjJMethodHeader): ObjJMethodDeclaration {
+        val script = "@implementation " + PlaceholderClassName + " \n " +
+                methodHeader.text + "\n" +
+                "{" + "\n" +
+                "    " + getDefaultReturnValueString(methodHeader.methodHeaderReturnTypeElement) + "\n" +
+                "}" + "\n" +
+                "@end"
         val file = createFileFromText(project, script)
         val implementationDeclaration = file.getChildOfType(ObjJImplementationDeclaration::class.java)!!
         return implementationDeclaration.methodDeclarationList[0]!!
     }
 
     private fun getDefaultReturnValueString(returnTypeElement: ObjJMethodHeaderReturnTypeElement?): String {
-        if (returnTypeElement == null || returnTypeElement.formalVariableType.text == "" || returnTypeElement.formalVariableType.text.toLowerCase() == "void") {
+        if (returnTypeElement == null || returnTypeElement.formalVariableType == null) {
             return ""
         }
         var defaultValue = "nil"
         val formalVariableType = returnTypeElement.formalVariableType
-        if (formalVariableType.varTypeBool != null) {
+        if (formalVariableType!!.varTypeBool != null) {
             defaultValue = "NO"
         } else if (formalVariableType.varTypeId != null || formalVariableType.className != null) {
             defaultValue = "Nil"

--- a/src/cappuccino/ide/intellij/plugin/psi/interfaces/ObjJMethodHeaderDeclaration.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/interfaces/ObjJMethodHeaderDeclaration.kt
@@ -12,5 +12,5 @@ interface ObjJMethodHeaderDeclaration<StubT : ObjJMethodHeaderDeclarationStub<*>
     val isStatic: Boolean
         get() = methodScope == MethodScope.STATIC
 
-    override fun getStub(): StubT
+    override fun getStub(): StubT?
 }

--- a/src/cappuccino/ide/intellij/plugin/psi/utils/CommentParserUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/utils/CommentParserUtil.kt
@@ -20,7 +20,7 @@ object CommentParserUtil {
 
     private val LOGGER: Logger = Logger.getLogger(CommentParserUtil::class.java.canonicalName)
     private val IDENT_REGEX = "[_\$a-zA-Z][_\$a-zA-Z0-9]*";
-    private val VARIABLE_TYPE_REGEX = Pattern.compile("[^@]*@var\\s+($IDENT_REGEX)\\s+($IDENT_REGEX).*")
+    private val VARIABLE_TYPE_REGEX = Pattern.compile(".*?@var\\s+($IDENT_REGEX)\\s+($IDENT_REGEX).*")
     private val IGNORER_REGEX = Pattern.compile("[^@]*@ignore\\s*([^\n]+)*")
 
     fun getVariableTypesInParent(element: ObjJNamedElement): String? {
@@ -34,6 +34,7 @@ object CommentParserUtil {
                         if (!matcher.group(2).equals(varName))
                             return@forEach
                         val type = matcher.group(1)
+                        LOGGER.info("Found type in comment $element.text is $type")
                         return type;
                     }
 

--- a/src/cappuccino/ide/intellij/plugin/psi/utils/CommentParserUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/utils/CommentParserUtil.kt
@@ -1,0 +1,64 @@
+package cappuccino.ide.intellij.plugin.psi.utils
+
+import cappuccino.ide.intellij.plugin.psi.ObjJComment
+import cappuccino.ide.intellij.plugin.psi.ObjJMethodHeader
+import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJBlock
+import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJHasContainingClass
+import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJMethodHeaderDeclaration
+import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJNamedElement
+import cappuccino.ide.intellij.plugin.psi.types.ObjJClassType
+import cappuccino.ide.intellij.plugin.psi.types.ObjJTokenSets
+import cappuccino.ide.intellij.plugin.psi.types.ObjJTypes
+import com.intellij.psi.PsiElement
+import com.intellij.psi.TokenType
+import com.intellij.psi.impl.source.tree.PsiCommentImpl
+import com.intellij.psi.util.PsiTreeUtil
+import java.util.logging.Logger
+import java.util.regex.Pattern
+
+object CommentParserUtil {
+
+    private val LOGGER: Logger = Logger.getLogger(CommentParserUtil::class.java.canonicalName)
+    private val IDENT_REGEX = "[_\$a-zA-Z][_\$a-zA-Z0-9]*";
+    private val VARIABLE_TYPE_REGEX = Pattern.compile("[^@]*@var\\s+($IDENT_REGEX)\\s+($IDENT_REGEX).*")
+    private val IGNORER_REGEX = Pattern.compile("[^@]*@ignore\\s*([^\n]+)*")
+
+    fun getVariableTypesInParent(element: ObjJNamedElement): String? {
+        val varName = element.text
+        element.getParentBlockChildrenOfType(PsiCommentImpl::class.java, true)
+                .sortedByDescending { it.textRange.startOffset }
+                .map { it.text }
+                .forEach { comment ->
+                    val matcher = VARIABLE_TYPE_REGEX.matcher(comment)
+                    if (matcher.find()) {
+                        if (!matcher.group(2).equals(varName))
+                            return@forEach
+                        val type = matcher.group(1)
+                        return type;
+                    }
+
+                }
+        return null
+    }
+
+    /**
+     * Find if given element has an @ignore comment preceeding it.
+     * Recursive in cases where mutliple comments are used in sequence
+     */
+    fun isIgnored(element:PsiElement) : Boolean {
+        var sibling = element.node.getPreviousNonEmptyNode(true);
+        while (sibling != null && sibling.elementType in ObjJTokenSets.COMMENTS) {
+            val match = IGNORER_REGEX.matcher(sibling.text)
+            if (match.find()) {
+                return true
+            }
+            sibling = sibling.getPreviousNonEmptyNode(true);
+        }
+        if (element is ObjJHasContainingClass) {
+            val containingClass = element.containingClass ?: return false
+            //return containingClass != element && isIgnored(containingClass)
+        }
+        return false
+    }
+
+}

--- a/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJAccessorPropertyPsiUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJAccessorPropertyPsiUtil.kt
@@ -103,7 +103,7 @@ object ObjJAccessorPropertyPsiUtil {
         if (setter != null) {
             val selectorStrings = listOf(setter)
             val paramTypes = listOf(varType)
-            return ObjJMethodHeaderStubImpl(null, variableDeclaration.containingClassName, false, selectorStrings, paramTypes, null, true, variableDeclaration.shouldResolve())
+            return ObjJMethodHeaderStubImpl(null, variableDeclaration.containingClassName, false, selectorStrings, paramTypes, null, true, variableDeclaration.shouldResolve(), false)
         }
         return null
     }
@@ -126,7 +126,7 @@ object ObjJAccessorPropertyPsiUtil {
                 ?: variableDeclaration.stub?.variableName ?: variableDeclaration.variableName?.text ?: return null
         val selectorStrings: List<String> = listOf(getter!!)
         val paramTypes = listOf(varType)
-        return ObjJMethodHeaderStubImpl(null, variableDeclaration.containingClassName, false, selectorStrings, paramTypes, varType, true, variableDeclaration.shouldResolve())
+        return ObjJMethodHeaderStubImpl(null, variableDeclaration.containingClassName, false, selectorStrings, paramTypes, varType, true, variableDeclaration.shouldResolve(), false)
     }
 
     private fun getGetterFromAccessorPropertyList(accessorProperties: List<ObjJAccessorProperty>): String? {

--- a/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJBlockPsiUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJBlockPsiUtil.kt
@@ -1,5 +1,6 @@
 package cappuccino.ide.intellij.plugin.psi.utils
 
+import cappuccino.ide.intellij.plugin.lang.ObjJFile
 import com.intellij.psi.PsiElement
 import cappuccino.ide.intellij.plugin.psi.*
 import cappuccino.ide.intellij.plugin.psi.interfaces.*
@@ -182,7 +183,7 @@ private fun getBlocksBlocks(block:ObjJBlock) : List<ObjJBlock> {
 }
 
 fun <T : PsiElement> PsiElement.getParentBlockChildrenOfType(aClass: Class<T>, recursive: Boolean): List<T> {
-    var block: ObjJBlock? = getParentOfType(ObjJBlock::class.java) ?: return emptyList()
+    var block: ObjJBlock? = getParentOfType(ObjJBlock::class.java) ?: return (this.containingFile as? ObjJFile)?.getFileChildrenOfType(aClass, recursive) ?: return listOf()
     val out = ArrayList<T>()
     do {
         if (block != null) {

--- a/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJMethodCallPsiUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJMethodCallPsiUtil.kt
@@ -95,12 +95,11 @@ fun getSelectorsFromIncompleteMethodCall(psiElement: PsiElement, selectorParentM
     // and create selector elements for later use.
     val orphanedSelectors = psiElement.parent.getChildrenOfType(ObjJTypes.ObjJ_ID)
     for (subSelector in orphanedSelectors) {
-        if (subSelector.text.isEmpty()) {
-            continue
-        }
-        selectors.add(++selectorIndex, ObjJElementFactory.createSelector(project, subSelector.text.replace("\\s+".toRegex(), "")))
+        val selector = ObjJElementFactory.createSelector(project, subSelector.text) ?: return selectors
+        selectors.add(++selectorIndex, selector)
     }
     //Finally add the current psi element as a selector
-    selectors.add(ObjJElementFactory.createSelector(project, psiElement.text.replace("\\s+".toRegex(), "")))
+    val selector = ObjJElementFactory.createSelector(project, psiElement.text) ?: return selectors
+    selectors.add(selector)
     return selectors
 }

--- a/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJMethodPsiUtils.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJMethodPsiUtils.kt
@@ -113,9 +113,7 @@ object ObjJMethodPsiUtils {
     }
 
     fun getSelectorString(selectorLiteral: ObjJSelectorLiteral): String {
-        return if (selectorLiteral.stub != null) {
-            selectorLiteral.stub.selectorString
-        } else getSelectorStringFromSelectorStrings(selectorLiteral.selectorStrings)
+        return selectorLiteral.stub?.selectorString ?: getSelectorStringFromSelectorStrings(selectorLiteral.selectorStrings)
     }
 
 
@@ -204,7 +202,7 @@ object ObjJMethodPsiUtils {
 
     fun getReturnType(methodHeader: ObjJMethodHeader, follow: Boolean): String {
         if (methodHeader.stub != null) {
-            return methodHeader.stub.returnTypeAsString
+            return methodHeader.stub!!.returnTypeAsString
         }
         val returnTypeElement = methodHeader.methodHeaderReturnTypeElement ?: return ObjJClassType.UNDETERMINED
         if (returnTypeElement.formalVariableType.atAction != null) {
@@ -294,7 +292,7 @@ object ObjJMethodPsiUtils {
 
     fun getReturnType(accessorProperty: ObjJAccessorProperty): String {
         if (accessorProperty.stub != null) {
-            return accessorProperty.stub.returnTypeAsString
+            return accessorProperty.stub!!.returnTypeAsString
         }
         val variableType = accessorProperty.getVarType()
         return variableType ?: UNDETERMINED
@@ -309,9 +307,7 @@ object ObjJMethodPsiUtils {
     // ===== Selector Functions ===== //
     // ============================== //
     fun getSelectorStrings(methodHeader: ObjJMethodHeader): List<String> {
-        return if (methodHeader.stub != null) {
-            methodHeader.stub.selectorStrings
-        } else ObjJMethodPsiUtils.getSelectorStringsFromMethodDeclarationSelectorList(methodHeader.methodDeclarationSelectorList)
+        return methodHeader.stub?.selectorStrings ?: ObjJMethodPsiUtils.getSelectorStringsFromMethodDeclarationSelectorList(methodHeader.methodDeclarationSelectorList)
     }
 
 
@@ -328,9 +324,7 @@ object ObjJMethodPsiUtils {
     }
 
     fun getSelectorString(methodHeader: ObjJMethodHeader): String {
-        return if (methodHeader.stub != null) {
-            methodHeader.stub.selectorString
-        } else ObjJMethodPsiUtils.getSelectorStringFromSelectorStrings(getSelectorStrings(methodHeader))
+        return methodHeader.stub?.selectorString ?: ObjJMethodPsiUtils.getSelectorStringFromSelectorStrings(getSelectorStrings(methodHeader))
     }
 
     fun setName(selectorElement: ObjJSelector, newSelectorValue: String): PsiElement {

--- a/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJPsiImplUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJPsiImplUtil.kt
@@ -360,9 +360,11 @@ object ObjJPsiImplUtil {
 
     @JvmStatic
     fun getSelectorStrings(selectorLiteral: ObjJSelectorLiteral): List<String> {
-        return if (selectorLiteral.stub != null && !selectorLiteral.stub.selectorStrings.isEmpty()) {
-            selectorLiteral.stub.selectorStrings
-        } else ObjJMethodPsiUtils.getSelectorStringsFromSelectorList(selectorLiteral.selectorList)
+        val selectors = selectorLiteral.stub?.selectorStrings ?: listOf()
+        return if (selectors.isNotEmpty()) {
+            selectors
+        } else
+            ObjJMethodPsiUtils.getSelectorStringsFromSelectorList(selectorLiteral.selectorList)
     }
 
     @JvmStatic

--- a/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJPsiImplUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJPsiImplUtil.kt
@@ -309,7 +309,7 @@ object ObjJPsiImplUtil {
 
     @JvmStatic
     fun getPossibleCallTargetTypes(callTarget:ObjJCallTarget) : List<String> {
-        return ObjJSelectorReferenceResolveUtil.getPossibleClassTypesForCallTarget(callTarget)
+        return Collections.singletonList(ObjJClassType.UNDETERMINED)//ObjJCallTargetUtil.getPossibleCallTargetTypes(callTarget)
     }
 
     @JvmStatic

--- a/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJPsiImplUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJPsiImplUtil.kt
@@ -309,7 +309,7 @@ object ObjJPsiImplUtil {
 
     @JvmStatic
     fun getPossibleCallTargetTypes(callTarget:ObjJCallTarget) : List<String> {
-        return Collections.singletonList(ObjJClassType.UNDETERMINED)//ObjJCallTargetUtil.getPossibleCallTargetTypes(callTarget)
+        return ObjJSelectorReferenceResolveUtil.getPossibleClassTypesForCallTarget(callTarget)
     }
 
     @JvmStatic

--- a/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJVariableNameUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/utils/ObjJVariableNameUtil.kt
@@ -23,12 +23,11 @@ object ObjJVariableNameUtil {
 
     fun getMatchingPrecedingVariableNameElements(variableName: ObjJCompositeElement, qualifiedIndex: Int): List<ObjJVariableName> {
         val startOffset = variableName.textRange.startOffset
-        val variableNameQualifiedString: String
-        if (variableName is ObjJVariableName) {
-            variableNameQualifiedString = getQualifiedNameAsString(variableName, qualifiedIndex)
+        val variableNameQualifiedString: String = if (variableName is ObjJVariableName) {
+            getQualifiedNameAsString(variableName, qualifiedIndex)
         } else {
             //LOGGER.log(Level.WARNING, "Trying to match variable name element to a non variable name. Element is of type: "+variableName.getNode().toString()+"<"+variableName.getText()+">");
-            variableNameQualifiedString = variableName.text
+            variableName.text
         }
 
         val hasContainingClass = ObjJHasContainingClassPsiUtil.getContainingClass(variableName) != null
@@ -286,7 +285,7 @@ object ObjJVariableNameUtil {
         val result = ArrayList<ObjJVariableName>()
         val block = element as? ObjJBlock ?: PsiTreeUtil.getParentOfType(element, ObjJBlock::class.java) ?: return result
         val bodyVariableAssignments = block.getBlockChildrenOfType(ObjJBodyVariableAssignment::class.java, true) as MutableList
-        bodyVariableAssignments.addAll(block!!.getParentBlockChildrenOfType(ObjJBodyVariableAssignment::class.java, true))
+        bodyVariableAssignments.addAll(block.getParentBlockChildrenOfType(ObjJBodyVariableAssignment::class.java, true))
         for (bodyVariableAssignment in bodyVariableAssignments) {
             ProgressIndicatorProvider.checkCanceled()
             result.addAll(getAllVariablesFromBodyVariableAssignment(bodyVariableAssignment, qualifiedNameIndex))
@@ -446,9 +445,7 @@ object ObjJVariableNameUtil {
         }
         val result = ArrayList<ObjJVariableName>()
         for (variableDeclaration in file.getChildrenOfType( ObjJGlobalVariableDeclaration::class.java)) {
-            if (variableDeclaration.variableName != null) {
-                result.add(variableDeclaration.variableName)
-            }
+            result.add(variableDeclaration.variableName)
         }
         return result
     }
@@ -552,7 +549,7 @@ object ObjJVariableNameUtil {
         }
         val result = ArrayList<ObjJVariableName>()
         for (parameterArg in functionDeclarationElement.formalParameterArgList) {
-            result.add((parameterArg as ObjJFormalParameterArg).variableName)
+            result.add(parameterArg.variableName)
         }
         return result
     }

--- a/src/cappuccino/ide/intellij/plugin/references/ObjJSelectorReferenceBack.java.bak
+++ b/src/cappuccino/ide/intellij/plugin/references/ObjJSelectorReferenceBack.java.bak
@@ -46,7 +46,7 @@ public class ObjJSelectorReferenceBack extends PsiPolyVariantReferenceBase<ObjJS
     }
 
     @NotNull
-    private List<String> getClassConstraints() {
+    private List<String> getCallTargetClassTypesIfMethodCall() {
         if (classConstraints != null) {
             return classConstraints;
         }
@@ -104,7 +104,7 @@ public class ObjJSelectorReferenceBack extends PsiPolyVariantReferenceBase<ObjJS
         if (element instanceof ObjJMethodHeader) {
             final ObjJMethodHeader methodHeader = (ObjJMethodHeader) element;
             if (methodHeader.getSelectorString().equals(fullSelector)) {
-                return sharesContainingClass(getClassConstraints(), methodHeader);
+                return sharesContainingClass(getCallTargetClassTypesIfMethodCall(), methodHeader);
             }
             //return methodHeader.getSelectorString().equals(selectorUpToAndSelf);
         }
@@ -130,7 +130,7 @@ public class ObjJSelectorReferenceBack extends PsiPolyVariantReferenceBase<ObjJS
             result = new ArrayList<>(getSelectorLiteralReferences());
         }
         for (ObjJInstanceVariableDeclaration variableDeclaration : ObjJClassInstanceVariableAccessorMethodIndex.getInstance().get(fullSelector, getProject())) {
-            if (sharesContainingClass(getClassConstraints(), variableDeclaration)) {
+            if (sharesContainingClass(getCallTargetClassTypesIfMethodCall(), variableDeclaration)) {
                 result.add(variableDeclaration.getAtAccessors() != null ? variableDeclaration.getAtAccessors() : variableDeclaration);
             }
         }
@@ -144,7 +144,7 @@ public class ObjJSelectorReferenceBack extends PsiPolyVariantReferenceBase<ObjJS
     }
 
     private List<ObjJSelector> prune(List<ObjJMethodHeaderDeclaration> methodHeaders) {
-        final List<String> classConstraints = getClassConstraints();
+        final List<String> classConstraints = getCallTargetClassTypesIfMethodCall();
         final List<ObjJSelector> result = new ArrayList<>();
         final List<ObjJSelector> others = new ArrayList<>();
         for (ObjJMethodHeaderDeclaration methodHeader : methodHeaders) {

--- a/src/cappuccino/ide/intellij/plugin/references/ObjJSelectorReferenceBack.java.bak
+++ b/src/cappuccino/ide/intellij/plugin/references/ObjJSelectorReferenceBack.java.bak
@@ -46,7 +46,7 @@ public class ObjJSelectorReferenceBack extends PsiPolyVariantReferenceBase<ObjJS
     }
 
     @NotNull
-    private List<String> getCallTargetClassTypesIfMethodCall() {
+    private List<String> getClassConstraints() {
         if (classConstraints != null) {
             return classConstraints;
         }
@@ -104,7 +104,7 @@ public class ObjJSelectorReferenceBack extends PsiPolyVariantReferenceBase<ObjJS
         if (element instanceof ObjJMethodHeader) {
             final ObjJMethodHeader methodHeader = (ObjJMethodHeader) element;
             if (methodHeader.getSelectorString().equals(fullSelector)) {
-                return sharesContainingClass(getCallTargetClassTypesIfMethodCall(), methodHeader);
+                return sharesContainingClass(getClassConstraints(), methodHeader);
             }
             //return methodHeader.getSelectorString().equals(selectorUpToAndSelf);
         }
@@ -130,7 +130,7 @@ public class ObjJSelectorReferenceBack extends PsiPolyVariantReferenceBase<ObjJS
             result = new ArrayList<>(getSelectorLiteralReferences());
         }
         for (ObjJInstanceVariableDeclaration variableDeclaration : ObjJClassInstanceVariableAccessorMethodIndex.getInstance().get(fullSelector, getProject())) {
-            if (sharesContainingClass(getCallTargetClassTypesIfMethodCall(), variableDeclaration)) {
+            if (sharesContainingClass(getClassConstraints(), variableDeclaration)) {
                 result.add(variableDeclaration.getAtAccessors() != null ? variableDeclaration.getAtAccessors() : variableDeclaration);
             }
         }
@@ -144,7 +144,7 @@ public class ObjJSelectorReferenceBack extends PsiPolyVariantReferenceBase<ObjJS
     }
 
     private List<ObjJSelector> prune(List<ObjJMethodHeaderDeclaration> methodHeaders) {
-        final List<String> classConstraints = getCallTargetClassTypesIfMethodCall();
+        final List<String> classConstraints = getClassConstraints();
         final List<ObjJSelector> result = new ArrayList<>();
         final List<ObjJSelector> others = new ArrayList<>();
         for (ObjJMethodHeaderDeclaration methodHeader : methodHeaders) {

--- a/src/cappuccino/ide/intellij/plugin/references/ObjJSelectorReferenceResolveUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/references/ObjJSelectorReferenceResolveUtil.kt
@@ -323,7 +323,7 @@ object ObjJSelectorReferenceResolveUtil {
         return classConstraints
     }
 
-    private fun getPossibleClassTypesForCallTarget(callTarget:ObjJCallTarget) : List<String> {
+    public fun getPossibleClassTypesForCallTarget(callTarget:ObjJCallTarget) : List<String> {
         val qualifiedReference = callTarget.qualifiedReference ?: return listOf()
         val methodCall = qualifiedReference.methodCall
         if (methodCall != null) {
@@ -336,7 +336,7 @@ object ObjJSelectorReferenceResolveUtil {
         if (variables.size != 1) {
             return listOf();
         }
-        val classFromComment = CommentParserUtil.getVariableTypesInParent(variables[0]) ?: return listOf()
+        val classFromComment = CommentParserUtil.getVariableTypesInParent(variables[0]) ?: return listOf(ObjJClassType.UNDETERMINED)
         return ObjJInheritanceUtil.getAllInheritedClasses(classFromComment, callTarget.project, true)
     }
 

--- a/src/cappuccino/ide/intellij/plugin/references/ObjJSelectorReferenceResolveUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/references/ObjJSelectorReferenceResolveUtil.kt
@@ -337,7 +337,7 @@ object ObjJSelectorReferenceResolveUtil {
             return listOf();
         }
         val classFromComment = CommentParserUtil.getVariableTypesInParent(variables[0]) ?: return listOf()
-        return listOf(classFromComment)
+        return ObjJInheritanceUtil.getAllInheritedClasses(classFromComment, callTarget.project, true)
     }
 
     class SelectorResolveResult<T> internal constructor(val naturalResult: List<T>, val otherResult: List<T>, val possibleContainingClassNames: List<String>) {

--- a/src/cappuccino/ide/intellij/plugin/references/ObjJSelectorReferenceResolveUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/references/ObjJSelectorReferenceResolveUtil.kt
@@ -323,7 +323,7 @@ object ObjJSelectorReferenceResolveUtil {
         return classConstraints
     }
 
-    public fun getPossibleClassTypesForCallTarget(callTarget:ObjJCallTarget) : List<String> {
+    private fun getPossibleClassTypesForCallTarget(callTarget:ObjJCallTarget) : List<String> {
         val qualifiedReference = callTarget.qualifiedReference ?: return listOf()
         val methodCall = qualifiedReference.methodCall
         if (methodCall != null) {
@@ -336,7 +336,7 @@ object ObjJSelectorReferenceResolveUtil {
         if (variables.size != 1) {
             return listOf();
         }
-        val classFromComment = CommentParserUtil.getVariableTypesInParent(variables[0]) ?: return listOf(ObjJClassType.UNDETERMINED)
+        val classFromComment = CommentParserUtil.getVariableTypesInParent(variables[0]) ?: return listOf()
         return ObjJInheritanceUtil.getAllInheritedClasses(classFromComment, callTarget.project, true)
     }
 

--- a/src/cappuccino/ide/intellij/plugin/stubs/ObjJStubVersions.kt
+++ b/src/cappuccino/ide/intellij/plugin/stubs/ObjJStubVersions.kt
@@ -1,7 +1,7 @@
 package cappuccino.ide.intellij.plugin.stubs
 
 object ObjJStubVersions {
-    private const val MINOR_VERSION = 0
+    private const val MINOR_VERSION = 2
     private const val MAJOR_VERSION = 4
     const val SOURCE_STUB_VERSION = MAJOR_VERSION + MINOR_VERSION
 }

--- a/src/cappuccino/ide/intellij/plugin/stubs/impl/ObjJAccessorPropertyStubImpl.kt
+++ b/src/cappuccino/ide/intellij/plugin/stubs/impl/ObjJAccessorPropertyStubImpl.kt
@@ -20,6 +20,8 @@ class ObjJAccessorPropertyStubImpl(parent: StubElement<*>, override val containi
     override val varType: String? = if (varType != null && !varType.isEmpty()) varType else null
     override val containingClassName: String = containingClass
 
+    override val ignored:Boolean = false
+
     override val paramTypes: List<String>
         get() = if (getter != null || varType == null) emptyList() else listOf(varType)
 

--- a/src/cappuccino/ide/intellij/plugin/stubs/impl/ObjJMethodHeaderStubImpl.kt
+++ b/src/cappuccino/ide/intellij/plugin/stubs/impl/ObjJMethodHeaderStubImpl.kt
@@ -7,7 +7,7 @@ import cappuccino.ide.intellij.plugin.stubs.types.ObjJStubTypes
 import cappuccino.ide.intellij.plugin.psi.types.ObjJClassType
 import cappuccino.ide.intellij.plugin.psi.utils.ObjJMethodPsiUtils
 
-class ObjJMethodHeaderStubImpl(parent: StubElement<*>?, className: String?, override val isStatic: Boolean, override val selectorStrings: List<String>, override val paramTypes: List<String>, returnType: String?, override val isRequired: Boolean, private val shouldResolve: Boolean) : ObjJStubBaseImpl<ObjJMethodHeaderImpl>(parent, ObjJStubTypes.METHOD_HEADER), ObjJMethodHeaderStub {
+class ObjJMethodHeaderStubImpl(parent: StubElement<*>?, className: String?, override val isStatic: Boolean, override val selectorStrings: List<String>, override val paramTypes: List<String>, returnType: String?, override val isRequired: Boolean, private val shouldResolve: Boolean, override val ignored:Boolean) : ObjJStubBaseImpl<ObjJMethodHeaderImpl>(parent, ObjJStubTypes.METHOD_HEADER), ObjJMethodHeaderStub {
     override val returnTypeAsString: String = returnType ?: ObjJClassType.UNDETERMINED
     override val containingClassName: String = className ?: ObjJClassType.UNDEF_CLASS_NAME
     override val selectorString: String = ObjJMethodPsiUtils.getSelectorStringFromSelectorStrings(selectorStrings)

--- a/src/cappuccino/ide/intellij/plugin/stubs/impl/ObjJSelectorLiteralStubImpl.kt
+++ b/src/cappuccino/ide/intellij/plugin/stubs/impl/ObjJSelectorLiteralStubImpl.kt
@@ -12,6 +12,9 @@ import java.util.Collections
 class ObjJSelectorLiteralStubImpl(parent: StubElement<*>, override val containingClassName: String, override val selectorStrings: List<String>, private val shouldResolve: Boolean) : ObjJStubBaseImpl<ObjJSelectorLiteralImpl>(parent, ObjJStubTypes.SELECTOR_LITERAL), ObjJSelectorLiteralStub {
     override val selectorString: String
 
+
+    override val ignored:Boolean = false
+
     override val paramTypes: List<String>
         get() = emptyList()
 

--- a/src/cappuccino/ide/intellij/plugin/stubs/interfaces/ObjJMethodHeaderDeclarationStub.kt
+++ b/src/cappuccino/ide/intellij/plugin/stubs/interfaces/ObjJMethodHeaderDeclarationStub.kt
@@ -23,4 +23,5 @@ interface ObjJMethodHeaderDeclarationStub<PsiT : PsiElement> : StubElement<PsiT>
 
     val isStatic: Boolean
 
+    val ignored: Boolean
 }

--- a/src/cappuccino/ide/intellij/plugin/stubs/types/ObjJMethodHeaderStubType.kt
+++ b/src/cappuccino/ide/intellij/plugin/stubs/types/ObjJMethodHeaderStubType.kt
@@ -12,6 +12,7 @@ import cappuccino.ide.intellij.plugin.psi.*
 import cappuccino.ide.intellij.plugin.psi.impl.ObjJMethodHeaderImpl
 import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJMethodHeaderDeclaration
 import cappuccino.ide.intellij.plugin.psi.utils.CommentParserUtil
+import cappuccino.ide.intellij.plugin.psi.utils.IgnoreFlags
 import cappuccino.ide.intellij.plugin.psi.utils.ObjJPsiImplUtil
 import cappuccino.ide.intellij.plugin.stubs.impl.ObjJMethodHeaderStubImpl
 import cappuccino.ide.intellij.plugin.stubs.interfaces.ObjJMethodHeaderStub
@@ -36,7 +37,7 @@ class ObjJMethodHeaderStubType internal constructor(
         val returnType: String? = null//methodHeader.getReturnType();
         val required = methodHeader.isRequired
         val shouldResolve = ObjJPsiImplUtil.shouldResolve(methodHeader)
-        val ignored = CommentParserUtil.isIgnored(methodHeader) || CommentParserUtil.isIgnored(methodHeader.parent)
+        val ignored = CommentParserUtil.isIgnored(methodHeader) || CommentParserUtil.isIgnored(methodHeader.parent, IgnoreFlags.IGNORE_METHOD)
         return ObjJMethodHeaderStubImpl(parentStub, containingClassName, methodHeader.isStatic, selectors, params, returnType, required, shouldResolve, ignored)
     }
 

--- a/src/cappuccino/ide/intellij/plugin/stubs/types/ObjJMethodHeaderStubType.kt
+++ b/src/cappuccino/ide/intellij/plugin/stubs/types/ObjJMethodHeaderStubType.kt
@@ -11,6 +11,7 @@ import cappuccino.ide.intellij.plugin.indices.StubIndexService
 import cappuccino.ide.intellij.plugin.psi.*
 import cappuccino.ide.intellij.plugin.psi.impl.ObjJMethodHeaderImpl
 import cappuccino.ide.intellij.plugin.psi.interfaces.ObjJMethodHeaderDeclaration
+import cappuccino.ide.intellij.plugin.psi.utils.CommentParserUtil
 import cappuccino.ide.intellij.plugin.psi.utils.ObjJPsiImplUtil
 import cappuccino.ide.intellij.plugin.stubs.impl.ObjJMethodHeaderStubImpl
 import cappuccino.ide.intellij.plugin.stubs.interfaces.ObjJMethodHeaderStub
@@ -35,7 +36,8 @@ class ObjJMethodHeaderStubType internal constructor(
         val returnType: String? = null//methodHeader.getReturnType();
         val required = methodHeader.isRequired
         val shouldResolve = ObjJPsiImplUtil.shouldResolve(methodHeader)
-        return ObjJMethodHeaderStubImpl(parentStub, containingClassName, methodHeader.isStatic, selectors, params, returnType, required, shouldResolve)
+        val ignored = CommentParserUtil.isIgnored(methodHeader) || CommentParserUtil.isIgnored(methodHeader.parent)
+        return ObjJMethodHeaderStubImpl(parentStub, containingClassName, methodHeader.isStatic, selectors, params, returnType, required, shouldResolve, ignored)
     }
 
     @Throws(IOException::class)
@@ -58,6 +60,7 @@ class ObjJMethodHeaderStubType internal constructor(
         stubOutputStream.writeName(stub.returnType.className)
         stubOutputStream.writeBoolean(stub.isRequired)
         stubOutputStream.writeBoolean(stub.shouldResolve())
+        stubOutputStream.writeBoolean(stub.ignored)
 
     }
 
@@ -79,7 +82,8 @@ class ObjJMethodHeaderStubType internal constructor(
         val returnType = StringRef.toString(stream.readName())
         val required = stream.readBoolean()
         val shouldResolve = stream.readBoolean()
-        return ObjJMethodHeaderStubImpl(parentStub, containingClassName, isStatic, selectors, params, returnType, required, shouldResolve)
+        val ignored = stream.readBoolean()
+        return ObjJMethodHeaderStubImpl(parentStub, containingClassName, isStatic, selectors, params, returnType, required, shouldResolve, ignored)
     }
 
 


### PR DESCRIPTION
Added method reference to point directly to method declarations of the variable if its type is known. Normally if a method selector on a method call is resolved, it shows a list of all methods with that same selector, despite different class types. This update causes resolution to point to method in the specific class of a variable, if its type is known either through calls to self, super or from variables labeled with an @&#x2060;var annotation comment