### PR TITLE
Added: Missing protocol methods fixer/helper (simple version)

### DIFF
--- a/src/cappuccino/ide/intellij/plugin/annotator/ObjJImplementationDeclarationAnnotatorUtil.kt
+++ b/src/cappuccino/ide/intellij/plugin/annotator/ObjJImplementationDeclarationAnnotatorUtil.kt
@@ -58,7 +58,7 @@ internal object ObjJImplementationDeclarationAnnotatorUtil {
             val unimplementedMethods = declaration.getUnimplementedProtocolMethods(protocolName)
             if (!unimplementedMethods.required.isEmpty()) {
                 annotationHolder.createErrorAnnotation(className, "Missing required protocol methods")
-                        .registerFix(ObjJMissingProtocolMethodFix(unimplementedMethods))
+                        .registerFix(ObjJMissingProtocolMethodFix(declaration, protocolName, unimplementedMethods))
             }
         }
     }

--- a/src/cappuccino/ide/intellij/plugin/fixes/ObjJMissingProtocolMethodFix.kt
+++ b/src/cappuccino/ide/intellij/plugin/fixes/ObjJMissingProtocolMethodFix.kt
@@ -1,24 +1,29 @@
 package cappuccino.ide.intellij.plugin.fixes
 
 import cappuccino.ide.intellij.plugin.inspections.ObjJInspectionProvider
+import cappuccino.ide.intellij.plugin.psi.ObjJElementFactory
+import cappuccino.ide.intellij.plugin.psi.ObjJImplementationDeclaration
 import com.intellij.codeInsight.intention.impl.BaseIntentionAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import com.intellij.util.IncorrectOperationException
-import cappuccino.ide.intellij.plugin.psi.ObjJMethodHeader
 import cappuccino.ide.intellij.plugin.psi.utils.ObjJProtocolDeclarationPsiUtil.ProtocolMethods
-import org.jetbrains.annotations.Nls
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.ui.Messages
+import com.intellij.psi.PsiElement
+import java.util.logging.Logger
+import javax.swing.SwingUtilities
 
-class ObjJMissingProtocolMethodFix(private val methodHeaders: ProtocolMethods) : BaseIntentionAction() {
+class ObjJMissingProtocolMethodFix(private val declaration:ObjJImplementationDeclaration, private val protocolName:String, private val methodHeaders: ProtocolMethods) : BaseIntentionAction() {
 
     override fun getText(): String {
         return "Implement missing protocol methodHeaders"
     }
 
     override fun getFamilyName(): String {
-        return ObjJInspectionProvider.GROUP_DISPLAY_NAME;
+        return ObjJInspectionProvider.GROUP_DISPLAY_NAME
     }
 
     override fun isAvailable(
@@ -29,11 +34,62 @@ class ObjJMissingProtocolMethodFix(private val methodHeaders: ProtocolMethods) :
     @Throws(IncorrectOperationException::class)
     override fun invoke(
             project: Project, editor: Editor, psiFile: PsiFile) {
-
+        try {
+            addMethods(project, editor.document)
+        } catch (e:Exception) {
+            SwingUtilities.invokeLater {
+                Messages.showDialog(project, MESSAGE.format(protocolName, "An unexpected error occurred"), TITLE, listOf("OK").toTypedArray(), 0, Messages.getWarningIcon())
+            }
+            Logger.getLogger(ObjJMissingProtocolMethodFix::class.java.canonicalName).severe(MESSAGE.format(protocolName, "An unexpected error occurred") + "; Error: "+e.message)
+        }
+        DaemonCodeAnalyzer.getInstance(declaration.project).restart(declaration.containingFile)
     }
 
-    private fun addMethods(project: Project, file: VirtualFile, methodHeaders: List<ObjJMethodHeader>) {
+    private fun addMethods(project: Project, document:Document) {
+        if (methodHeaders.required.isEmpty()) {
+            return
+        }
+        val requiredHeaders = methodHeaders.required;
+        val sibling:PsiElement? = when {
+            declaration.atEnd != null -> {
+                declaration.atEnd!!
+            }
+            declaration.lastChild != null -> {
+                declaration.lastChild
+            }
+            else -> {
+                declaration.node.treeNext?.psi
+            }
+        }
+        if (sibling == null) {
+            SwingUtilities.invokeLater {
+                Messages.showDialog(project, MESSAGE.format(protocolName, "Implementation declaration is not well formed"), TITLE, listOf("OK").toTypedArray(), 0, Messages.getWarningIcon())
+            }
+            return
+        }
+        val numberOfRequiredNewLinesBeforeMethods = numberOfReturnsNeeded(sibling, true, 2)
+        var newLinesBefore = ""
+        for (i in 0 until numberOfRequiredNewLinesBeforeMethods) {
+            newLinesBefore += "\n"
+        }
+        val methodsText = ObjJElementFactory.createMethodDeclarationsText(requiredHeaders)
+        document.insertString(sibling.textRange.startOffset, newLinesBefore + methodsText + "\n\n")
+    }
 
+    companion object {
+        const val TITLE = "Protocol Implementation Failure"
+        const val MESSAGE:String = "Failed to create placeholder methods for protocol %s. %s"
 
+        private fun numberOfReturnsNeeded(element:PsiElement, before:Boolean, required:Int) : Int {
+            var remaining = required;
+            var prevSibling:PsiElement = element.prevSibling ?: return required
+            for (i in 0 until required) {
+                if (prevSibling.text?.endsWith("\n") == true) {
+                    remaining -= 1;
+                }
+                prevSibling = prevSibling.prevSibling ?: return remaining
+            }
+            return remaining
+        }
     }
 }

--- a/src/cappuccino/ide/intellij/plugin/psi/ObjJElementFactory.kt
+++ b/src/cappuccino/ide/intellij/plugin/psi/ObjJElementFactory.kt
@@ -49,6 +49,12 @@ object ObjJElementFactory {
         return file.firstChild
     }
 
+    fun createNewLine(project: Project): PsiElement {
+        val scriptText = "\n"
+        val file = createFileFromText(project, scriptText)
+        return file.firstChild
+    }
+
     fun createSemiColonErrorElement(project: Project): PsiErrorElement? {
         val scriptText = "?*__ERR_SEMICOLON__*?"
         val file = createFileFromText(project, scriptText)
@@ -65,7 +71,7 @@ object ObjJElementFactory {
     }
 
     fun createIgnoreComment(project: Project, elementType: IgnoreUtil.ElementType): ObjJComment {
-        val scriptText = "//ignore " + elementType.type
+        val scriptText = "// @ignore " + elementType.type
         val file = createFileFromText(project, scriptText)
         return file.getChildOfType(ObjJComment::class.java)!!
     }
@@ -74,25 +80,54 @@ object ObjJElementFactory {
         return PsiFileFactory.getInstance(project).createFileFromText("dummy.j", ObjJLanguage.instance, text) as ObjJFile
     }
 
-    private fun createMethodDeclaration(project: Project, methodHeader: ObjJMethodHeader): ObjJMethodDeclaration {
-        val script = "@implementation " + PlaceholderClassName + " \n " +
-                methodHeader.text + "\n" +
-                "{" + "\n" +
-                "    " + getDefaultReturnValueString(methodHeader.methodHeaderReturnTypeElement) + "\n" +
-                "}" + "\n" +
-                "@end"
+    fun createMethodDeclaration(project: Project, methodHeader: ObjJMethodHeader): ObjJMethodDeclaration {
+        val script ="""
+                @implementation ${PlaceholderClassName}
+                ${methodHeader.text}
+                {
+                    //@todo provide implementation
+                    ${getDefaultReturnValueString(methodHeader.methodHeaderReturnTypeElement)};
+                }
+                @end""".trimIndent()
         val file = createFileFromText(project, script)
         val implementationDeclaration = file.getChildOfType(ObjJImplementationDeclaration::class.java)!!
         return implementationDeclaration.methodDeclarationList[0]!!
     }
 
+
+    fun createMethodDeclarations(project: Project, methodHeaders: List<ObjJMethodHeader>): List<ObjJMethodDeclaration> {
+        val script ="@implementation $PlaceholderClassName\n"+
+                createMethodDeclarationsText(methodHeaders) +
+                "@end"
+        val file = createFileFromText(project, script)
+        val implementationDeclaration = file.getChildOfType(ObjJImplementationDeclaration::class.java)!!
+        return implementationDeclaration.methodDeclarationList
+    }
+
+    fun createMethodDeclarationsText(methodHeaders:List<ObjJMethodHeader>) : String {
+        var out:String = "";
+        methodHeaders.forEach {
+            out += "\n\n"+
+            createMethodDeclarationText(it)
+        }
+        return out.trim()
+    }
+
+    fun createMethodDeclarationText(methodHeader: ObjJMethodHeader) : String {
+        return  "${methodHeader.text}\n" +
+                "{\n" +
+                "   //@todo provide implementation\n" +
+                "   ${getDefaultReturnValueString(methodHeader.methodHeaderReturnTypeElement)}\n" +
+                "}"
+    }
+
     private fun getDefaultReturnValueString(returnTypeElement: ObjJMethodHeaderReturnTypeElement?): String {
-        if (returnTypeElement == null || returnTypeElement.formalVariableType == null) {
+        if (returnTypeElement == null || returnTypeElement.formalVariableType.text == "" || returnTypeElement.formalVariableType.text.toLowerCase() == "void") {
             return ""
         }
         var defaultValue = "nil"
         val formalVariableType = returnTypeElement.formalVariableType
-        if (formalVariableType!!.varTypeBool != null) {
+        if (formalVariableType.varTypeBool != null) {
             defaultValue = "NO"
         } else if (formalVariableType.varTypeId != null || formalVariableType.className != null) {
             defaultValue = "Nil"


### PR DESCRIPTION
A simple version of the protocol methods fixer/helper is implemented in this pull request. It is simple because it only does required protocols, and it does not take into account optionals, or perhaps a user not wanting to implement all required protocols(though I do not know why). A more refined one will perhaps be to allow the selection of which methods to implement. Currently the fixer adds a required return function, though this might not be ideal, perhaps place a NotImplemented exception statement instead.